### PR TITLE
add color variables

### DIFF
--- a/.storybook/storybook.scss
+++ b/.storybook/storybook.scss
@@ -1,3 +1,13 @@
+:root {
+  color: var(--sui-black);
+  background-color: var(--sui-white);
+}
+
+[data-theme="dark"] {
+  color: var(--sui-white);
+  background-color: var(--sui-black);
+}
+
 html,
 body {
   padding: 0;

--- a/src/Accordion/Accordion.module.scss
+++ b/src/Accordion/Accordion.module.scss
@@ -1,22 +1,22 @@
 .container {
-  color: var(--sui-black);
-  background-color: var(--sui-white);
+  color: var(--sui-accordion-fg);
+  background-color: var(--sui-accordion-bg);
   font-family: var(--sui-font-family);
-  border-left: 1px solid var(--sui-border);
-  border-right: 1px solid var(--sui-border);
+  border-left: 1px solid var(--sui-accordion-border);
+  border-right: 1px solid var(--sui-accordion-border);
   box-sizing: border-box;
   transition: var(--sui-transition);
 
   &:first-of-type {
     border-top-left-radius: var(--sui-border-radius-small);
     border-top-right-radius: var(--sui-border-radius-small);
-    border-top: 1px solid var(--sui-border);
+    border-top: 1px solid var(--sui-accordion-border);
   }
 
   &:last-of-type {
     border-bottom-left-radius: var(--sui-border-radius-small);
     border-bottom-right-radius: var(--sui-border-radius-small);
-    border-bottom: 1px solid var(--sui-border);
+    border-bottom: 1px solid var(--sui-accordion-border);
   }
 
   &[data-expanded="true"] {
@@ -58,7 +58,8 @@
   width: 100%;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background-color: var(--sui-white);
+  color: var(--sui-accordion-summary-fg);
+  background-color: var(--sui-accordion-summary-bg);
   border-radius: var(--sui-border-radius-small);
   border: none;
   outline: none;
@@ -68,6 +69,7 @@
 
   &[disabled] {
     cursor: default;
+    color: var(--sui-accordion-summary-disabled);
   }
 }
 

--- a/src/Accordion/index.stories.tsx
+++ b/src/Accordion/index.stories.tsx
@@ -3,6 +3,7 @@ import Accordion from "./index";
 import { AccordionTemplateProps } from "./types";
 import Button from "../Button/index";
 import { useState } from "react";
+import StoryBook from "../Storybook";
 
 const Template: React.FC<AccordionTemplateProps> = (args) => {
   const { title, ...props } = args;
@@ -15,73 +16,63 @@ const Template: React.FC<AccordionTemplateProps> = (args) => {
   }
 
   return (
-    <>
-      <h2>{title}</h2>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-evenly",
-          flexDirection: "column",
-          gap: "16px",
-        }}
-      >
-        <span>{`Default expanded accordions will be expanded upon page load.`}</span>
-        <div>
-          <Accordion {...props} />
-          <Accordion
-            {...props}
-            summary="Default Expanded Accordion"
-            defaultExpanded
-          />
-          <Accordion {...props} />
-        </div>
-        <span>{`Disabled accordions will not expand or collapse on click. But they will persist their state.`}</span>
-        <div>
-          <Accordion {...props} summary="Disabled Accordion" disabled />
-          <Accordion
-            {...props}
-            summary="Expanded Disabled Accordion"
-            defaultExpanded
-            disabled
-          />
-          <Accordion {...props} />
-        </div>
-        <span>{`Controlled accordions' state is controlled by its parent. In this example, only one accordion can be expanded at a time.`}</span>
-        <div>
-          <Accordion
-            {...props}
-            summary="Controlled Accordion 1"
-            expanded={expanded === "a1"}
-            onExpand={() => handleExpanded("a1")}
-          />
-          <Accordion
-            {...props}
-            summary="Controlled Accordion 2"
-            expanded={expanded === "a2"}
-            onExpand={() => handleExpanded("a2")}
-          />
-          <Accordion
-            {...props}
-            summary="Controlled Accordion 3"
-            expanded={expanded === "a3"}
-            onExpand={() => handleExpanded("a3")}
-          />
-        </div>
-        <span>{`Accordions with "unmountOnExit" will not render their details when collapsed to increase performance. This option also disables the animations.`}</span>
-        <div>
-          <Accordion
-            {...props}
-            summary="Unmount on Exit Accordion"
-            unmountOnExit
-          />
-          <Accordion
-            {...props}
-            summary="Unmount on Exit Accordion"
-            unmountOnExit
-          />
-        </div>
+    <StoryBook title={title}>
+      <span>{`Default expanded accordions will be expanded upon page load.`}</span>
+      <div>
+        <Accordion {...props} />
+        <Accordion
+          {...props}
+          summary="Default Expanded Accordion"
+          defaultExpanded
+        />
+        <Accordion {...props} />
       </div>
-    </>
+      <span>{`Disabled accordions will not expand or collapse on click. But they will persist their state.`}</span>
+      <div>
+        <Accordion {...props} summary="Disabled Accordion" disabled />
+        <Accordion
+          {...props}
+          summary="Expanded Disabled Accordion"
+          defaultExpanded
+          disabled
+        />
+        <Accordion {...props} />
+      </div>
+      <span>{`Controlled accordions' state is controlled by its parent. In this example, only one accordion can be expanded at a time.`}</span>
+      <div>
+        <Accordion
+          {...props}
+          summary="Controlled Accordion 1"
+          expanded={expanded === "a1"}
+          onExpand={() => handleExpanded("a1")}
+        />
+        <Accordion
+          {...props}
+          summary="Controlled Accordion 2"
+          expanded={expanded === "a2"}
+          onExpand={() => handleExpanded("a2")}
+        />
+        <Accordion
+          {...props}
+          summary="Controlled Accordion 3"
+          expanded={expanded === "a3"}
+          onExpand={() => handleExpanded("a3")}
+        />
+      </div>
+      <span>{`Accordions with "unmountOnExit" will not render their details when collapsed to increase performance. This option also disables the animations.`}</span>
+      <div style={{width: "100%"}}>
+        <Accordion
+          {...props}
+          summary="Unmount on Exit Accordion"
+          unmountOnExit
+        />
+        <Accordion
+          {...props}
+          summary="Unmount on Exit Accordion"
+          unmountOnExit
+        />
+      </div>
+    </StoryBook>
   );
 };
 

--- a/src/style/components/accordion.scss
+++ b/src/style/components/accordion.scss
@@ -1,0 +1,17 @@
+:root {
+  --sui-accordion-fg: var(--sui-black);
+  --sui-accordion-bg: var(--sui-white);
+  --sui-accordion-border: var(--sui-gray-300);
+  --sui-accordion-summary-fg: inherit;
+  --sui-accordion-summary-bg: transparent;
+  --sui-accordion-summary-disabled: var(--sui-gray-400);
+}
+
+[data-theme="dark"] {
+  --sui-accordion-fg: var(--sui-white);
+  --sui-accordion-bg: var(--sui-black);
+  --sui-accordion-border: var(--sui-gray-700);
+  --sui-accordion-summary-fg: inherit;
+  --sui-accordion-summary-bg: transparent;
+  --sui-accordion-summary-disabled: var(--sui-gray-600);
+}

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -2,6 +2,7 @@
 @import "colors/colors-light";
 @import "colors/colors-dark";
 
+@import "components/accordion.scss";
 @import "components/button";
 @import "components/tooltip";
 @import "components/popover";


### PR DESCRIPTION
Add color variables for Accordion component and improve storybook preview.
Add color and background-color to `preview.scss` for light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new CSS variables for theming in Storybook, enhancing visual presentation based on user preferences.
	- Enhanced styling specificity for the accordion component with new design variables for better alignment with the overall design system.
	- Added a modular `StoryBook` component for improved organization of the Accordion story.
	- Implemented a new SCSS file for accordion styling, allowing for flexible theming options.

- **Bug Fixes**
	- Ensured visual consistency of the Accordion display by adjusting styles for specific instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->