### PR TITLE
hotfix/SBP-218-CSS-typo

### DIFF
--- a/src/style/components/button.scss
+++ b/src/style/components/button.scss
@@ -76,7 +76,7 @@
   --sui-button-secondary-ghost-hover-bg: var(--sui-gray-750);
   --sui-button-secondary-ghost-hover-text: var(--sui-white);
   --sui-button-destructive-ghost-bg: var(--sui-transparent);
-  --sui-button-destructive-ghost-text: var(-sui-error-dark-600);
+  --sui-button-destructive-ghost-text: var(--sui-error-dark-600);
   --sui-button-destructive-ghost-hover-bg: var(--sui-error-dark-600);
   --sui-button-destructive-ghost-hover-text: var(--sui-white);
   --sui-button-disabled-bg: var(--sui-gray-600);


### PR DESCRIPTION
Fixed a CSS variable typo that was causing parsing error on the client side on Next15.
