### PR TITLE
fix/SBP-204-radio-bugs

### DIFF
--- a/docs/pages/docs/formComponents/radio.mdx
+++ b/docs/pages/docs/formComponents/radio.mdx
@@ -82,8 +82,8 @@ The Radio component is designed for selecting a single option from a set of mutu
             justifyContent: 'space-evenly',
           }}
         >
-          <Radio label="Radio Option 1" name="default" value="default1" />
-          <Radio label="Radio Option 2" name="default" value="default2" />
+          <Radio label="Radio Option 1" name="e1" value="e1v1" checked />
+          <Radio label="Radio Option 2" name="e1" value="e1v2" checked />
         </div>
       </FormOnChange>
     </Preview>
@@ -142,16 +142,16 @@ The Radio component is designed for selecting a single option from a set of mutu
     <Radio
       checked
       label="Radio Option 1"
-      name="default"
+      name="e2"
       title="Radio"
-      value="default1"
+      value="e2v1"
     />
     <Radio
       checked
       label="Radio Option 2"
-      name="default"
+      name="e2"
       title="Radio"
-      value="default2"
+      value="e2v2"
     />
 
   </div>
@@ -214,16 +214,16 @@ The Radio component is designed for selecting a single option from a set of mutu
     <Radio
       disabled
       label="Radio Option 1"
-      name="default"
+      name="e3"
       title="Radio"
-      value="default1"
+      value="e3v1"
     />
     <Radio
       disabled
       label="Radio Option 2"
-      name="default"
+      name="e3"
       title="Radio"
-      value="default2"
+      value="e3v2"
     />
 
   </div>
@@ -284,16 +284,18 @@ The Radio component is designed for selecting a single option from a set of mutu
     <Radio
       error="Error Message"
       label="Radio Option 1"
-      name="default"
+      name="e4"
       title="Radio"
-      value="default1"
+      value="e4v1"
+      checked
     />
     <Radio
       error="Error Message"
       label="Radio Option 2"
-      name="default"
+      name="e4"
       title="Radio"
-      value="default2"
+      value="e4v2"
+      checked
     />
   </div>
   </FormOnChange>

--- a/docs/pages/docs/formComponents/radioGroup.mdx
+++ b/docs/pages/docs/formComponents/radioGroup.mdx
@@ -76,15 +76,15 @@ The RadioGroup component is designed to manage a set of radio buttons that allow
     <FormOnChange>
    <RadioGroup
       label="RadioGroup"
-      name="default"
+      name="e1"
       options={[
         {
           label: 'Radio Option 1',
-          value: 'default1'
+          value: 'e1v1'
         },
         {
           label: 'Radio Option 2',
-          value: 'default2'
+          value: 'e1v2'
         }
       ]}
     />
@@ -94,69 +94,6 @@ The RadioGroup component is designed to manage a set of radio buttons that allow
   <Tabs.Tab>
     ```jsx copy showLineNumbers
     <RadioGroup
-      label="RadioGroup"
-      name="default"
-      onChange={handleChange}
-      options={[
-        {
-          label: 'Radio Option 1',
-          value: 'default1'
-        },
-        {
-          label: 'Radio Option 2',
-          value: 'default2'
-        }
-      ]}
-    />
-    ```
-
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```jsx copy showLineNumbers
-    <Controller
-        name="input"
-        control={control}
-        render={({ field }) => (
-          <RadioGroup
-            value={watch("input")}
-            {...field}
-          />
-        )}
-    />
-    ```
-  </Tabs.Tab>
-</Tabs>
-
-### Radio Group Component Checked
-
-<Tabs items={["Preview", "Code", "React Hook Form"]}>
-  <Tabs.Tab>
-  <Preview height="200px">
-
-        <FormOnChange>
-      <RadioGroup
-      checked
-      label="RadioGroup"
-      name="default"
-      options={[
-        {
-          label: 'Radio Option 1',
-          value: 'default1'
-        },
-        {
-          label: 'Radio Option 2',
-          value: 'default2'
-        }
-      ]}
-    />
-
-  </FormOnChange>
-  </Preview>
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```jsx copy showLineNumbers
-    <RadioGroup
-      checked
       label="RadioGroup"
       name="default"
       onChange={handleChange}
@@ -200,15 +137,15 @@ The RadioGroup component is designed to manage a set of radio buttons that allow
      <RadioGroup
       disabled
       label="RadioGroup"
-      name="default"
+      name="e2"
       options={[
         {
           label: 'Radio Option 1',
-          value: 'default1'
+          value: 'e2v1'
         },
         {
           label: 'Radio Option 2',
-          value: 'default2'
+          value: 'e2v2'
         }
       ]}
     />
@@ -262,15 +199,15 @@ The RadioGroup component is designed to manage a set of radio buttons that allow
      <RadioGroup
       error="Error Message"
       label="RadioGroup"
-      name="default"
+      name="e3"
       options={[
         {
           label: 'Radio Option 1',
-          value: 'default1'
+          value: 'e3v1'
         },
         {
           label: 'Radio Option 2',
-          value: 'default2'
+          value: 'e3v2'
         }
       ]}
     />


### PR DESCRIPTION
- Fixed some of the bugs that caused the Radio components to not work in docs.
- Removed RadioGroup with Checked section in docs because RadioGroup does not accept a property named `checked`.
- I was unable to fix some of the issues however. For example, the Radio components will not work if the `checked` property is not provided. The RadioGroup component page has 2 distinct RadioGroup examples with different names and options prop but still seem to affact one another. These issues most likely stem from the react-form-elements repository.