### PR TITLE
Feat/sbp 252 datatable design

### DIFF
--- a/src/DataTable/DataTable.module.scss
+++ b/src/DataTable/DataTable.module.scss
@@ -37,63 +37,6 @@
   }
 }
 
-/* Pagination */
-
-.paginationContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-wrap: nowrap;
-  border: none;
-  padding: var(--sui-datatable-padding-small);
-}
-
-.paginationContent {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sui-datatable-gap-small);
-}
-
-.pageInfo {
-  display: flex;
-  gap: var(--sui-datatable-gap-small);
-}
-
-.rowsPerPage {
-  display: flex;
-  align-items: center;
-
-  label {
-    margin-right: var(--sui-text-margin);
-    font-size: var(--sui-text-small-fs);
-    line-height: var(--sui-text-small-lh);
-  }
-
-  .rowsPerPageSelect {
-    border: none;
-    background: var(--sui-gray-150);
-    border-radius: var(--sui-datatable-border-radius-small);
-    height: 24px;
-  }
-}
-
-.paginationInfo {
-  font-size: var(--sui-text-small-fs);
-}
-
-.paginationButtons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sui-datatable-gap-small);
-
-  /** TODO: Temporary fix for pagination misalignment. The issue stems from the Button component's styling */
-  > button {
-    min-width: unset !important;
-    height: unset !important;
-  }
-}
-
 /* Select and Highlight */
 
 .rowSelected {
@@ -140,151 +83,6 @@
       var(--sui-datatable-white)
     );
   }
-}
-
-/* Filter */
-
-.filterContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: var(--sui-datatable-margin-small);
-  color: var(--sui-black);
-}
-
-.filterIconButton {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  padding: var(--sui-datatable-padding-small);
-  border: none;
-  border-radius: var(--sui-datatable-border-radius-small);
-  text-align: center;
-  z-index: 20;
-  background-color: var(--sui-gray-150);
-
-  &:hover {
-    background-color: var(--sui-datatable-filter-hover);
-  }
-}
-
-.filterOperatorDropdown {
-  display: flex;
-  border: none;
-  background: var(--sui-gray-150);
-  border-radius: var(--sui-datatable-border-radius-small);
-  max-width: 4.7rem;
-  text-overflow: ellipsis;
-}
-
-.filterPanel {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--sui-datatable-gap-small);
-  margin-right: var(--sui-datatable-margin-small);
-  transition: all 0.75s ease;
-  transform: translateX(25px);
-  opacity: 0;
-  height: 1.5rem;
-
-  > button {
-    background-color: var(--sui-gray-150);
-  }
-}
-
-.filterContentInner {
-  display: flex;
-}
-
-.filterOperator {
-  display: flex;
-  height: 1rem;
-  max-width: 4rem;
-}
-
-.filterInput {
-  display: flex;
-  max-width: 5rem;
-  text-align: center;
-  background: var(--sui-gray-150);
-  border: none;
-  border-radius: var(--sui-datatable-border-radius-small);
-  text-overflow: ellipsis;
-}
-
-.columnSelect {
-  display: flex;
-  position: absolute;
-  right: 5%;
-  top: 0%;
-  border-radius: var(--sui-datatable-border-radius-small);
-  color: var(--sui-black);
-  background-color: var(--sui-gray-50);
-  padding: var(--sui-datatable-padding-small);
-  font-size: 0.8rem;
-  z-index: 3;
-
-  input[type='checkbox'] {
-    appearance: auto;
-    color-scheme: light;
-  }
-}
-
-.openPanel {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.closePanel {
-  opacity: 0;
-  transform: translateX(25px);
-}
-
-/* Sort */
-
-.sortingContainer {
-  position: relative;
-  display: flex;
-  margin-left: 5px;
-}
-
-.sortingButton {
-  display: flex;
-  position: absolute;
-  top: -1rem;
-  left: 0;
-  margin: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  color: var(--sui-datatable-white);
-}
-
-.sortDropdown {
-  position: absolute;
-  top: -1.8rem;
-  left: 2rem;
-  background: var(--sui-datatable-black);
-  border: 1px solid var(--sui-datatable-border);
-  border-radius: var(--sui-datatable-border-radius-small);
-  z-index: 10;
-  display: flex;
-  flex-direction: column;
-}
-
-.sortOptionButton {
-  border: none;
-  background: none;
-  padding: 5px;
-  text-align: left;
-  cursor: pointer;
-  width: 100%;
-}
-
-.sortOptionButton:hover {
-  background-color: var(--sui-gray-150);
 }
 
 /* Table */
@@ -407,14 +205,6 @@
     height: 56px;
   }
 
-  @media (min-width: 576px) {
-    // Small devices (landscape phones, 576px and up)
-  }
-
-  @media (min-width: 768px) {
-    // Medium devices (tablets, 768px and up)
-  }
-
   @media (min-width: 992px) {
     // Large devices (desktops, 992px and up)
     border-top: none;
@@ -495,18 +285,6 @@
         }
       }
     }
-  }
-
-  @media (min-width: 1200px) {
-    // X-Large devices (large desktops, 1200px and up)
-  }
-
-  @media (min-width: 1400px) {
-    // XX-Large devices (larger desktops, 1400px and up)
-  }
-
-  @media (min-width: 2160px) {
-    // XXX-Large devices (larger desktops, 2160px and up)
   }
 }
 

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -193,11 +193,10 @@ const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
             {sorting && (
               <Sorting
                 column={col}
-                sortColumn={sortColumn}
+                isSorted={dataIndex === sortColumn}
                 setSortColumn={setSortColumn}
                 sortOrder={sortOrder}
                 setSortOrder={setSortOrder}
-                showIcon={hoveredColumn === dataIndex}
               />
             )}
           </div>

--- a/src/DataTable/index.tsx
+++ b/src/DataTable/index.tsx
@@ -28,6 +28,7 @@ const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
       sorting = false,
       emptyText,
       rowClassName,
+      i18n,
     },
     ref
   ) => {
@@ -240,6 +241,8 @@ const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
       key: item?.key ?? index,
     }));
 
+    const { pagination: paginationTranslations, filter: filterTranslations } = i18n || {};
+
     return (
       <div ref={ref}>
         <div
@@ -268,6 +271,7 @@ const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
               setSelectedColumns={setSelectedColumns}
               setHighlightedRows={setHighlightedRows}
               setCurrentPage={setCurrentPage}
+              i18n={filterTranslations}
             />
           )}
         </div>
@@ -312,6 +316,7 @@ const DataTable = forwardRef<HTMLDivElement, DataTableProps>(
             setCurrentRowsPerPage={setCurrentRowsPerPage}
             rowsPerPageOptions={rowsPerPageOptions}
             dataLength={totalItems}
+            i18n={paginationTranslations}
           />
         )}
       </div>

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -24,6 +24,7 @@ interface DataTableI18N {
     next: string;
   };
   filter: {
+    reset: string;
     columns: string;
     operator: string;
     selectOperator: string;

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -1,4 +1,4 @@
-import { Key } from 'react';
+import { Dispatch, Key, SetStateAction } from 'react';
 import { ColumnType } from 'rc-table';
 
 export interface DataItem {
@@ -88,11 +88,10 @@ export interface PaginationProps {
 
 export interface SortingProps {
   column: ColumnType<DataItem>;
-  sortColumn: string | null;
-  sortOrder: SortOrder;
   setSortColumn: (columnKey: string | null) => void;
-  setSortOrder: (order: SortOrder) => void;
-  showIcon: boolean;
+  isSorted: boolean;
+  sortOrder: SortOrder;
+  setSortOrder: Dispatch<SetStateAction<SortOrder>>;
 }
 
 export type SortOrder = 'ascend' | 'descend' | null;

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -42,9 +42,13 @@ interface DataTableI18N {
   };
 }
 
+interface DataTableColumn extends ColumnType<DataItem> {
+  filterable?: boolean;
+}
+
 export interface DataTableProps {
   data: DataItem[];
-  columns: ColumnType<DataItem>[];
+  columns: DataTableColumn[];
   rowsPerPage?: number;
   pagination?: boolean;
   rowsPerPageOptions?: number[];
@@ -64,7 +68,7 @@ export interface DataTableProps {
 }
 
 export interface FilterProps {
-  columns: ColumnType<DataItem>[];
+  columns: DataTableColumn[];
   data: DataItem[];
   filterValue: string;
   setFilterValue: (value: string) => void;

--- a/src/DataTable/types.ts
+++ b/src/DataTable/types.ts
@@ -16,6 +16,31 @@ export interface CheckboxProps {
   indeterminate?: boolean;
 }
 
+interface DataTableI18N {
+  pagination: {
+    rows: string;
+    of: string;
+    previous: string;
+    next: string;
+  };
+  filter: {
+    columns: string;
+    operator: string;
+    selectOperator: string;
+    typeValue: string;
+    notNeeded: string;
+    contains: string;
+    doesNotContain: string;
+    equals: string;
+    doesNotEqual: string;
+    startsWith: string;
+    endsWith: string;
+    isEmpty: string;
+    isNotEmpty: string;
+    isAnyOf: string;
+  };
+}
+
 export interface DataTableProps {
   data: DataItem[];
   columns: ColumnType<DataItem>[];
@@ -34,6 +59,7 @@ export interface DataTableProps {
   maxHeight?: number;
   minHeight?: number;
   sorting?: boolean;
+  i18n?: Partial<DataTableI18N>;
 }
 
 export interface FilterProps {
@@ -47,6 +73,7 @@ export interface FilterProps {
   setSelectedColumns: React.Dispatch<React.SetStateAction<string[]>>;
   setHighlightedRows: (rows: (Key | undefined)[]) => void;
   setCurrentPage: (page: number) => void;
+  i18n?: Partial<Pick<DataTableI18N, "filter">["filter"]>;
 }
 
 export interface PaginationProps {
@@ -56,6 +83,7 @@ export interface PaginationProps {
   setCurrentRowsPerPage: (rowsPerPage: number) => void;
   rowsPerPageOptions: number[];
   dataLength: number;
+  i18n?: Partial<Pick<DataTableI18N, "pagination">["pagination"]>;
 }
 
 export interface SortingProps {

--- a/src/DataTable/ui/Filter.module.scss
+++ b/src/DataTable/ui/Filter.module.scss
@@ -4,6 +4,7 @@
   align-items: center;
   margin-bottom: var(--sui-datatable-margin-small);
   color: var(--sui-black);
+  width: 100%;
 }
 
 .filterIconButton {
@@ -28,19 +29,19 @@
   border: none;
   background: var(--sui-gray-150);
   border-radius: var(--sui-datatable-border-radius-small);
-  max-width: 4.7rem;
   text-overflow: ellipsis;
 }
 
 .filterPanel {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--sui-datatable-gap-small);
   margin-right: var(--sui-datatable-margin-small);
   transition: all 0.75s ease;
   transform: translateX(25px);
   opacity: 0;
-  height: 1.5rem;
+  width: 100%;
 
   > button {
     background-color: var(--sui-gray-150);
@@ -54,12 +55,10 @@
 .filterOperator {
   display: flex;
   height: 1rem;
-  max-width: 4rem;
 }
 
 .filterInput {
   display: flex;
-  max-width: 5rem;
   text-align: center;
   background: var(--sui-gray-150);
   border: none;

--- a/src/DataTable/ui/Filter.module.scss
+++ b/src/DataTable/ui/Filter.module.scss
@@ -1,0 +1,96 @@
+.filterContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: var(--sui-datatable-margin-small);
+  color: var(--sui-black);
+}
+
+.filterIconButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  padding: var(--sui-datatable-padding-small);
+  border: none;
+  border-radius: var(--sui-datatable-border-radius-small);
+  text-align: center;
+  z-index: 20;
+  background-color: var(--sui-gray-150);
+
+  &:hover {
+    background-color: var(--sui-datatable-filter-hover);
+  }
+}
+
+.filterOperatorDropdown {
+  display: flex;
+  border: none;
+  background: var(--sui-gray-150);
+  border-radius: var(--sui-datatable-border-radius-small);
+  max-width: 4.7rem;
+  text-overflow: ellipsis;
+}
+
+.filterPanel {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sui-datatable-gap-small);
+  margin-right: var(--sui-datatable-margin-small);
+  transition: all 0.75s ease;
+  transform: translateX(25px);
+  opacity: 0;
+  height: 1.5rem;
+
+  > button {
+    background-color: var(--sui-gray-150);
+  }
+}
+
+.filterContentInner {
+  display: flex;
+}
+
+.filterOperator {
+  display: flex;
+  height: 1rem;
+  max-width: 4rem;
+}
+
+.filterInput {
+  display: flex;
+  max-width: 5rem;
+  text-align: center;
+  background: var(--sui-gray-150);
+  border: none;
+  border-radius: var(--sui-datatable-border-radius-small);
+  text-overflow: ellipsis;
+}
+
+.columnSelect {
+  display: flex;
+  position: absolute;
+  right: 5%;
+  top: 0%;
+  border-radius: var(--sui-datatable-border-radius-small);
+  color: var(--sui-black);
+  background-color: var(--sui-gray-50);
+  padding: var(--sui-datatable-padding-small);
+  font-size: 0.8rem;
+  z-index: 3;
+
+  input[type='checkbox'] {
+    appearance: auto;
+    color-scheme: light;
+  }
+}
+
+.openPanel {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.closePanel {
+  opacity: 0;
+  transform: translateX(25px);
+}

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -167,6 +167,13 @@ const Filter = ({
     dictionary.isAnyOf,
   ];
 
+  function toggleReset() {
+    setFilterValue("");
+    setDebouncedFilterValue("");
+    setFilterOperator("Operator");
+    setSelectedColumns([]);
+  }
+
   return (
     <div className={styles.filterContainer}>
       <div
@@ -175,6 +182,9 @@ const Filter = ({
           isContainerOpen ? styles.openPanel : styles.closePanel
         )}
       >
+        <Button size='small' variant='link' onClick={toggleReset}>
+          Reset
+        </Button>
         <Button
           size="small"
           variant="link"

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -195,24 +195,28 @@ const Filter = ({
         </Button>
         {isColumnDropdownOpen && (
           <div className={styles.columnSelect} ref={columnDropdownRef}>
-            {columns.map((col) => (
-              <label key={col.key}>
-                <input
-                  type="checkbox"
-                  value={col.key?.toString()}
-                  checked={selectedColumns.includes(col.key?.toString() ?? '')}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    setSelectedColumns((prev) =>
-                      e.target.checked
-                        ? [...prev, value]
-                        : prev.filter((colKey) => colKey !== value)
-                    );
-                  }}
-                />
-                {col.title}
-              </label>
-            ))}
+            {columns.map((col) => {
+              if (col.filterable !== false) return (
+                <label key={col.key}>
+                  <input
+                    type="checkbox"
+                    value={col.key?.toString()}
+                    checked={selectedColumns.includes(col.key?.toString() ?? '')}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setSelectedColumns((prev) =>
+                        e.target.checked
+                          ? [...prev, value]
+                          : prev.filter((colKey) => colKey !== value)
+                      );
+                    }}
+                  />
+                  {col.title}
+                </label>
+              );
+
+              return null;
+            })}
           </div>
         )}
 

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -5,6 +5,7 @@ import { FilterProps } from '../types';
 import clsx from 'clsx';
 
 const i18nDefaults = {
+  reset: "Reset",
   columns: "Columns",
   contains: "contains",
   doesNotContain: "does not contain",
@@ -183,7 +184,7 @@ const Filter = ({
         )}
       >
         <Button size='small' variant='link' onClick={toggleReset}>
-          Reset
+          {dictionary.reset}
         </Button>
         <Button
           size="small"

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-// eslint-disable-next-line css-modules/no-unused-class
-import styles from '../DataTable.module.scss';
+import styles from './Filter.module.scss';
 import Button from '../../Button/index';
 import { FilterProps } from '../types';
 import clsx from 'clsx';

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -5,6 +5,23 @@ import Button from '../../Button/index';
 import { FilterProps } from '../types';
 import clsx from 'clsx';
 
+const i18nDefaults = {
+  columns: "Columns",
+  contains: "contains",
+  doesNotContain: "does not contain",
+  doesNotEqual: "does not equal",
+  endsWith: "ends with",
+  equals: "equals",
+  isAnyOf: "is any of",
+  isEmpty: "is empty",
+  isNotEmpty: "is not empty",
+  notNeeded: "Not needed",
+  operator: "Operator",
+  selectOperator: "Select operator",
+  startsWith: "starts with",
+  typeValue: "Type value",
+};
+
 const Filter = ({
   columns,
   data,
@@ -16,11 +33,14 @@ const Filter = ({
   setSelectedColumns,
   setHighlightedRows,
   setCurrentPage,
+  i18n = i18nDefaults,
 }: FilterProps) => {
   const [isContainerOpen, setIsContainerOpen] = useState(false);
   const [isColumnDropdownOpen, setIsColumnDropdownOpen] = useState(false);
   const [debouncedFilterValue, setDebouncedFilterValue] = useState(filterValue);
   const columnDropdownRef = useRef<HTMLDivElement>(null);
+
+  const dictionary = {...i18nDefaults, ...i18n };
 
   const operatorsRequiringValue = [
     'contains',
@@ -136,6 +156,18 @@ const Filter = ({
     setDebouncedFilterValue(e.target.value);
   };
 
+  const filterOperators = [
+    dictionary.contains,
+    dictionary.doesNotContain,
+    dictionary.equals,
+    dictionary.doesNotEqual,
+    dictionary.startsWith,
+    dictionary.endsWith,
+    dictionary.isEmpty,
+    dictionary.isNotEmpty,
+    dictionary.isAnyOf,
+  ];
+
   return (
     <div className={styles.filterContainer}>
       <div
@@ -149,7 +181,7 @@ const Filter = ({
           variant="link"
           onClick={() => setIsColumnDropdownOpen(!isColumnDropdownOpen)}
         >
-          Columns
+          {dictionary.columns}
         </Button>
         {isColumnDropdownOpen && (
           <div className={styles.columnSelect} ref={columnDropdownRef}>
@@ -180,7 +212,7 @@ const Filter = ({
           className={styles.filterOperatorDropdown}
         >
           <option disabled value="Operator">
-            Operator
+            {dictionary.operator}
           </option>
           {filterOperators.map((operator) => (
             <option key={operator} value={operator}>
@@ -195,10 +227,10 @@ const Filter = ({
           onChange={handleInputChange}
           placeholder={
             filterOperator === 'Operator'
-              ? 'Select operator'
+              ? dictionary.selectOperator
               : operatorsRequiringValue.includes(filterOperator)
-                ? 'Type value'
-                : 'Not needed'
+                ? dictionary.typeValue
+                : dictionary.notNeeded
           }
           className={styles.filterInput}
           disabled={
@@ -227,17 +259,5 @@ const Filter = ({
     </div>
   );
 };
-
-const filterOperators = [
-  'contains',
-  'does not contain',
-  'equals',
-  'does not equal',
-  'starts with',
-  'ends with',
-  'is empty',
-  'is not empty',
-  'is any of',
-];
 
 export default Filter;

--- a/src/DataTable/ui/Filter.tsx
+++ b/src/DataTable/ui/Filter.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './Filter.module.scss';
 import Button from '../../Button/index';
+import Dropdown from '../../floatings/Dropdown';
 import { FilterProps } from '../types';
 import clsx from 'clsx';
 
@@ -36,11 +37,9 @@ const Filter = ({
   i18n = i18nDefaults,
 }: FilterProps) => {
   const [isContainerOpen, setIsContainerOpen] = useState(false);
-  const [isColumnDropdownOpen, setIsColumnDropdownOpen] = useState(false);
   const [debouncedFilterValue, setDebouncedFilterValue] = useState(filterValue);
-  const columnDropdownRef = useRef<HTMLDivElement>(null);
 
-  const dictionary = {...i18nDefaults, ...i18n };
+  const dictionary = { ...i18nDefaults, ...i18n };
 
   const operatorsRequiringValue = [
     'contains',
@@ -74,27 +73,6 @@ const Filter = ({
 
     return () => clearTimeout(handler);
   }, [debouncedFilterValue]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        columnDropdownRef.current &&
-        !columnDropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsColumnDropdownOpen(false);
-      }
-    };
-
-    if (isColumnDropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isColumnDropdownOpen]);
 
   const applyFilterOnClick = () => {
     if (filterOperator === 'Operator' || selectedColumns.length === 0) {
@@ -186,40 +164,30 @@ const Filter = ({
         <Button size='small' variant='link' onClick={toggleReset}>
           {dictionary.reset}
         </Button>
-        <Button
-          size="small"
-          variant="link"
-          onClick={() => setIsColumnDropdownOpen(!isColumnDropdownOpen)}
+        <Dropdown
+          component={
+            <Button size='small' variant='link' fluid>{dictionary.columns}</Button>
+          }
         >
-          {dictionary.columns}
-        </Button>
-        {isColumnDropdownOpen && (
-          <div className={styles.columnSelect} ref={columnDropdownRef}>
-            {columns.map((col) => {
-              if (col.filterable !== false) return (
-                <label key={col.key}>
-                  <input
-                    type="checkbox"
-                    value={col.key?.toString()}
-                    checked={selectedColumns.includes(col.key?.toString() ?? '')}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      setSelectedColumns((prev) =>
-                        e.target.checked
-                          ? [...prev, value]
-                          : prev.filter((colKey) => colKey !== value)
-                      );
-                    }}
-                  />
-                  {col.title}
-                </label>
-              );
-
-              return null;
-            })}
-          </div>
-        )}
-
+          {columns.filter((col) => col.filterable !== false).map((col) => (
+            <label key={col.key}>
+              <input
+                type="checkbox"
+                value={col.key?.toString()}
+                checked={selectedColumns.includes(col.key?.toString() ?? '')}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setSelectedColumns((prev) =>
+                    e.target.checked
+                      ? [...prev, value]
+                      : prev.filter((colKey) => colKey !== value)
+                  );
+                }}
+              />
+              {col.title}
+            </label>
+          ))}
+        </Dropdown>
         <select
           value={filterOperator}
           onChange={(e) => setFilterOperator(e.target.value)}

--- a/src/DataTable/ui/Pagination.module.scss
+++ b/src/DataTable/ui/Pagination.module.scss
@@ -1,0 +1,55 @@
+
+.paginationContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-wrap: nowrap;
+  border: none;
+  padding: var(--sui-datatable-padding-small);
+}
+
+.paginationContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sui-datatable-gap-small);
+}
+
+.pageInfo {
+  display: flex;
+  gap: var(--sui-datatable-gap-small);
+}
+
+.rowsPerPage {
+  display: flex;
+  align-items: center;
+
+  label {
+    margin-right: var(--sui-text-margin);
+    font-size: var(--sui-text-small-fs);
+    line-height: var(--sui-text-small-lh);
+  }
+
+  .rowsPerPageSelect {
+    border: none;
+    background: var(--sui-gray-150);
+    border-radius: var(--sui-datatable-border-radius-small);
+    height: 24px;
+  }
+}
+
+.paginationInfo {
+  font-size: var(--sui-text-small-fs);
+}
+
+.paginationButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sui-datatable-gap-small);
+
+  /** TODO: Temporary fix for pagination misalignment. The issue stems from the Button component's styling */
+  > button {
+    min-width: unset !important;
+    height: unset !important;
+  }
+}

--- a/src/DataTable/ui/Pagination.module.scss
+++ b/src/DataTable/ui/Pagination.module.scss
@@ -32,7 +32,6 @@
 
   .rowsPerPageSelect {
     border: none;
-    background: var(--sui-gray-150);
     border-radius: var(--sui-datatable-border-radius-small);
     height: 24px;
   }

--- a/src/DataTable/ui/Pagination.tsx
+++ b/src/DataTable/ui/Pagination.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line css-modules/no-unused-class
-import styles from '../DataTable.module.scss';
+import styles from './Pagination.module.scss';
 import Button from '../../Button/index';
 import { PaginationProps } from '../types';
 

--- a/src/DataTable/ui/Pagination.tsx
+++ b/src/DataTable/ui/Pagination.tsx
@@ -4,6 +4,13 @@ import styles from '../DataTable.module.scss';
 import Button from '../../Button/index';
 import { PaginationProps } from '../types';
 
+const i18nDefaults = {
+  next: "Next",
+  of: "of",
+  previous: "Previous",
+  rows: "Rows",
+};
+
 const Pagination = ({
   currentPage,
   setCurrentPage,
@@ -11,7 +18,10 @@ const Pagination = ({
   setCurrentRowsPerPage,
   rowsPerPageOptions,
   dataLength,
+  i18n = i18nDefaults,
 }: PaginationProps) => {
+  const dictionary = {...i18nDefaults, ...i18n };
+
   const totalPages = Math.ceil(dataLength / currentRowsPerPage);
 
   const startItem = (currentPage - 1) * currentRowsPerPage + 1;
@@ -37,7 +47,7 @@ const Pagination = ({
       <div className={styles.paginationContent}>
         <div className={styles.pageInfo}>
           <div className={styles.rowsPerPage}>
-            <label htmlFor="rowsPerPage">Rows:</label>
+            <label htmlFor="rowsPerPage">{dictionary.rows}</label>
             <select
               id="rowsPerPage"
               value={currentRowsPerPage}
@@ -53,7 +63,7 @@ const Pagination = ({
           </div>
           <div className={styles.paginationInfo}>
             <span>
-              {startItem}–{endItem} of {dataLength}
+              {`${startItem}-${endItem} ${dictionary.of} ${dataLength}`}
             </span>
           </div>
         </div>
@@ -65,7 +75,7 @@ const Pagination = ({
             onClick={handlePreviousPage}
             disabled={currentPage === 1}
           >
-            Previous
+            {dictionary.previous}
           </Button>
           <Button
             size="small"
@@ -74,7 +84,7 @@ const Pagination = ({
             onClick={handleNextPage}
             disabled={currentPage === totalPages}
           >
-            Next
+            {dictionary.next}
           </Button>
         </div>
       </div>

--- a/src/DataTable/ui/Sort.module.scss
+++ b/src/DataTable/ui/Sort.module.scss
@@ -36,28 +36,3 @@
     color: var(--sui-gray-500);
   }
 }
-
-.sortDropdown {
-  position: absolute;
-  top: -1.8rem;
-  left: 2rem;
-  background: var(--sui-datatable-black);
-  border: 1px solid var(--sui-datatable-border);
-  border-radius: var(--sui-datatable-border-radius-small);
-  z-index: 10;
-  display: flex;
-  flex-direction: column;
-}
-
-.sortOptionButton {
-  border: none;
-  background: none;
-  padding: 5px;
-  text-align: left;
-  cursor: pointer;
-  width: 100%;
-}
-
-.sortOptionButton:hover {
-  background-color: var(--sui-gray-150);
-}

--- a/src/DataTable/ui/Sort.module.scss
+++ b/src/DataTable/ui/Sort.module.scss
@@ -2,6 +2,18 @@
   position: relative;
   display: flex;
   margin-left: 5px;
+
+  &[data-sort="ascend"] {
+    .sortingButton > svg {
+      transform: rotate(0deg);
+    }
+  }
+
+  &[data-sort="descend"] {
+    .sortingButton > svg {
+      transform: rotate(-180deg);
+    }
+  }
 }
 
 .sortingButton {
@@ -15,6 +27,14 @@
   cursor: pointer;
   padding: 0;
   color: var(--sui-datatable-white);
+
+  > svg {
+    width: 16px;
+    height: 16px;
+    transform: rotate(-90deg);
+    transition: transform 200ms;
+    color: var(--sui-gray-500);
+  }
 }
 
 .sortDropdown {

--- a/src/DataTable/ui/Sort.module.scss
+++ b/src/DataTable/ui/Sort.module.scss
@@ -1,0 +1,43 @@
+.sortingContainer {
+  position: relative;
+  display: flex;
+  margin-left: 5px;
+}
+
+.sortingButton {
+  display: flex;
+  position: absolute;
+  top: -1rem;
+  left: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--sui-datatable-white);
+}
+
+.sortDropdown {
+  position: absolute;
+  top: -1.8rem;
+  left: 2rem;
+  background: var(--sui-datatable-black);
+  border: 1px solid var(--sui-datatable-border);
+  border-radius: var(--sui-datatable-border-radius-small);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+}
+
+.sortOptionButton {
+  border: none;
+  background: none;
+  padding: 5px;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+}
+
+.sortOptionButton:hover {
+  background-color: var(--sui-gray-150);
+}

--- a/src/DataTable/ui/Sort.tsx
+++ b/src/DataTable/ui/Sort.tsx
@@ -1,91 +1,38 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { SortOrder, SortingProps } from '../types';
+import React from 'react';
+import { SortingProps } from '../types';
 import Button from '../../Button/index';
+import DownArrow from "../../icons/DownArrow";
 
 import styles from './Sort.module.scss';
 
 const Sorting = ({
   column,
-  sortColumn,
-  sortOrder,
+  isSorted,
   setSortColumn,
+  sortOrder,
   setSortOrder,
-  showIcon,
 }: SortingProps) => {
-  const [openDropdown, setOpenDropdown] = useState(false);
-  const sortingRef = useRef<HTMLDivElement>(null);
+  function toggleSort() {
+    setSortOrder((prev) => {
+      if (!prev || !isSorted) return "descend";
+      if (prev === "descend") return "ascend";
+      return null;
+    });
+    setSortColumn(column.dataIndex as string);
+  }
 
-  const handleSortOrderChange = (order: SortOrder) => {
-    if (sortOrder === order && sortColumn === column.dataIndex) {
-      setSortOrder(null);
-      setSortColumn(null);
-    } else {
-      setSortOrder(order);
-      setSortColumn(column.dataIndex as string);
-    }
-    setOpenDropdown(false);
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        sortingRef.current &&
-        !sortingRef.current.contains(event.target as Node)
-      ) {
-        setOpenDropdown(false);
-      }
-    };
-
-    if (openDropdown) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [openDropdown]);
+  const sort = isSorted && sortOrder;
 
   return (
-    <div className={styles.sortingContainer} ref={sortingRef}>
-      {(showIcon || openDropdown) && (
-        <Button
-          className={styles.sortingButton}
-          variant="link"
-          size="icon"
-          onClick={(e) => {
-            e.stopPropagation();
-            setOpenDropdown(!openDropdown);
-          }}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="18"
-            fill="currentColor"
-            viewBox="0 0 256 256"
-          >
-            <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM40,72H216a8,8,0,0,0,0-16H40a8,8,0,0,0,0,16ZM216,184H40a8,8,0,0,0,0,16H216a8,8,0,0,0,0-16Z"></path>
-          </svg>
-        </Button>
-      )}
-      {openDropdown && (
-        <div className={styles.sortDropdown}>
-          <button
-            className={styles.sortOptionButton}
-            onClick={() => handleSortOrderChange('ascend')}
-          >
-            Ascend
-          </button>
-          <button
-            className={styles.sortOptionButton}
-            onClick={() => handleSortOrderChange('descend')}
-          >
-            Descend
-          </button>
-        </div>
-      )}
+    <div className={styles.sortingContainer} data-sort={`${sort}`}>
+      <Button
+        className={styles.sortingButton}
+        variant="link"
+        size="icon"
+        onClick={toggleSort}
+      >
+        <DownArrow />
+      </Button>
     </div>
   );
 };

--- a/src/DataTable/ui/Sort.tsx
+++ b/src/DataTable/ui/Sort.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { SortOrder, SortingProps } from '../types';
 import Button from '../../Button/index';
 
-// eslint-disable-next-line css-modules/no-unused-class
-import styles from '../DataTable.module.scss';
+import styles from './Sort.module.scss';
 
 const Sorting = ({
   column,


### PR DESCRIPTION
- Several styling fixes
- Added i18n property, which can be used to pass custom labels for different languages
- Add reset filters button
- Add filterable option to columns prop. Defaults to true.
- Rework sort button

Failed to merge and cleanup Table and DataTable styles. The classes were too tangled and I couldn't get it working. Similarly I couldn't implement a filter to show selected rows.