### PR TITLE
Fix/sbp 256 divider rework

### DIFF
--- a/docs/pages/docs/components/divider.mdx
+++ b/docs/pages/docs/components/divider.mdx
@@ -83,13 +83,7 @@ npm i @start-base/start-ui
         }}
       >
         <span>Hello</span>
-        <Divider
-          className=""
-          component="li"
-          contentAlign="center"
-          orientation="horizontal"
-          variant="fullWidth"
-        />
+        <Divider align="center" orientation="horizontal" variant="full" />
         <span>World</span>
       </div>
     </Preview>
@@ -106,13 +100,7 @@ npm i @start-base/start-ui
       }}
     >
       <span>Hello</span>
-      <Divider
-        className=""
-        component="li"
-        contentAlign="center"
-        orientation="horizontal"
-        variant="fullWidth"
-      />
+      <Divider align="center" orientation="horizontal" variant="full" />
       <span>World</span>
     </div>
     ```
@@ -134,13 +122,7 @@ npm i @start-base/start-ui
         }}
       >
         <span>Hello</span>
-        <Divider
-          className=""
-          component="div"
-          contentAlign="center"
-          orientation="vertical"
-          variant="fullWidth"
-        />
+        <Divider align="center" orientation="vertical" variant="full" />
         <span>World</span>
       </div>
     </Preview>
@@ -157,13 +139,7 @@ npm i @start-base/start-ui
       }}
     >
       <span>Hello</span>
-      <Divider
-        className=""
-        component="div"
-        contentAlign="center"
-        orientation="vertical"
-        variant="fullWidth"
-      />
+      <Divider align="center" orientation="vertical" variant="full" />
       <span>World</span>
     </div>
     ```
@@ -185,13 +161,7 @@ npm i @start-base/start-ui
         }}
       >
         <span>Hello</span>
-        <Divider
-          className=""
-          component="div"
-          contentAlign="center"
-          orientation="horizontal"
-          variant="fullWidth"
-        >
+        <Divider align="center" orientation="horizontal" variant="full">
           Startbase
         </Divider>
         <span>World</span>
@@ -210,13 +180,7 @@ npm i @start-base/start-ui
       }}
     >
       <span>Hello</span>
-      <Divider
-        className=""
-        component="div"
-        contentAlign="center"
-        orientation="horizontal"
-        variant="fullWidth"
-      >
+      <Divider align="center" orientation="horizontal" variant="full">
         Startbase
       </Divider>
       <span>World</span>
@@ -227,10 +191,11 @@ npm i @start-base/start-ui
 
 ## API
 
-| Name         | Type     | Default      | Variants                               | Description                  |
-| ------------ | -------- | ------------ | -------------------------------------- | ---------------------------- |
-| orientation  | `string` | `horizontal` | `horizontal` `vertical`                | Orientation of the Divider   |
-| variant      | `string` | `default`    | `default` `fullWidth` `inset` `middle` | Variant of the Divider       |
-| component    | `string` | `div`        |                                        | Component of the Divider     |
-| contentAlign | `string` | `center`     |                                        | Content align of the Divider |
-| className    | `string` |              |                                        | Classname of the Divider     |
+| Name        | Type      | Default               | Description                                                                                      |
+| ----------- | --------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| orientation | `string`  | `'horizontal'`        | Orientation of the Divider. Accepts values of type `'horizontal' \| 'vertical'`.                 |
+| variant     | `string`  | `'full'`              | Styling variant of the Divider. Accepts values of type `'full' \| 'start' \| 'center' \| 'end'`. |
+| align       | `string`  | `'center'`            | Content alignment of the Divider. Accepts values of type `'start' \| 'center' \|`.               |
+| color       | `string`  | `'var(--sui-border)'` | Divider lines color. Accepts any hex color value, CSS colors or variables.                       |
+| size        | `string`  | `'1px'`               | Divider line size. Accepts any pixel or REM value.                                               |
+| round       | `boolean` | `false`               | Controls whether the Divider line should have round corners or not.                              |

--- a/src/Divider/Divider.module.scss
+++ b/src/Divider/Divider.module.scss
@@ -1,96 +1,76 @@
 .root {
   display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  min-height: 1px;
-  position: relative;
-  text-align: center;
-  font-family: var(--sui-font-family);
-}
+  justify-content: center;
+  gap: 0.5rem;
 
-.root::before,
-.root::after {
-  display: flex;
-  content: '';
-  height: 1px;
-  width: 100%;
-  border: none;
-  border-bottom: 1px solid var(--sui-border);
-}
+  &:empty {
+    gap: 0;
+  }
 
-.root[data-align='start']::before {
-  width: 10%;
-}
+  &:before,
+  &:after {
+    content: "";
+    display: flex;
+    flex: 1;
+    height: var(--sui-divider-size);
+    width: var(--sui-divider-size);
+    background-color: var(--sui-divider-color);
+  }
 
-.root[data-align='end']::after {
-  width: 10%;
-}
+  &[data-round="true"] {
+    &:before,
+    &:after {
+      border-radius: var(--sui-divider-size);
+    }
+  }
 
-.root:empty {
-  border: none;
-  border-bottom: 1px solid var(--sui-border);
-}
+  &[aria-orientation="horizontal"] {
+    &[data-variant="start"],
+    &[data-variant="center"] {
+      &:after {
+        margin-right: 5%;
+      }
+    }
+  
+    &[data-variant="end"],
+    &[data-variant="center"] {
+      &:before {
+        margin-left: 5%;
+      }
+    }
+  }
 
-.root:empty::after,
-.root:empty::before {
-  display: none;
-}
+  &[data-align="start"] {
+    &:after {
+      flex: 3;
+    }
+  }
 
-.root[data-variant='start'] {
-  width: 90%;
-}
+  &[data-align="end"] {
+    &:before {
+      flex: 3;
+    }
+  }
 
-.root[data-variant='end'] {
-  width: 90%;
-  align-self: flex-end;
-}
+  &[aria-orientation="vertical"] {
+    flex-direction: column;
 
-.root[data-variant='center'] {
-  width: 90%;
-  align-self: center;
-}
+    &[data-variant="start"],
+    &[data-variant="center"] {
+      &:after {
+        margin-bottom: 5%;
+      }
+    }
 
-.root[aria-orientation='vertical'] {
-  width: max-content;
-  min-width: 1px;
-  height: 100%;
-  flex-direction: column;
-}
-
-.root[aria-orientation='vertical']::after,
-.root[aria-orientation='vertical']::before {
-  width: 1px;
-  height: 100%;
-  border: none;
-  border-right: 1px solid var(--sui-border);
-}
-
-.root[aria-orientation='vertical']:empty {
-  width: 1px;
-  height: 100%;
-  border: none;
-  border-right: 1px solid var(--sui-border);
-}
-
-.root[aria-orientation='vertical'][data-align='start']::before {
-  height: 10%;
-}
-
-.root[aria-orientation='vertical'][data-align='end']::after {
-  height: 10%;
-}
-
-.root[aria-orientation='vertical'][data-variant='start'] {
-  height: 90%;
-}
-
-.root[aria-orientation='vertical'][data-variant='end'] {
-  height: 90%;
-  align-self: flex-end;
-}
-
-.root[aria-orientation='vertical'][data-variant='center'] {
-  height: 90%;
-  align-self: center;
+    &[data-variant="end"],
+    &[data-variant="center"] {
+      &:before {
+        margin-top: 5%;
+      }
+    }
+  }
 }

--- a/src/Divider/Divider.module.scss
+++ b/src/Divider/Divider.module.scss
@@ -13,7 +13,7 @@
 
   &:before,
   &:after {
-    content: "";
+    content: '';
     display: flex;
     flex: 1;
     height: var(--sui-divider-size);
@@ -21,53 +21,53 @@
     background-color: var(--sui-divider-color);
   }
 
-  &[data-round="true"] {
+  &[data-round='true'] {
     &:before,
     &:after {
       border-radius: var(--sui-divider-size);
     }
   }
 
-  &[aria-orientation="horizontal"] {
-    &[data-variant="start"],
-    &[data-variant="center"] {
+  &[aria-orientation='horizontal'] {
+    &[data-variant='start'],
+    &[data-variant='center'] {
       &:after {
         margin-right: 5%;
       }
     }
-  
-    &[data-variant="end"],
-    &[data-variant="center"] {
+
+    &[data-variant='end'],
+    &[data-variant='center'] {
       &:before {
         margin-left: 5%;
       }
     }
   }
 
-  &[data-align="start"] {
+  &[data-align='start'] {
     &:after {
       flex: 3;
     }
   }
 
-  &[data-align="end"] {
+  &[data-align='end'] {
     &:before {
       flex: 3;
     }
   }
 
-  &[aria-orientation="vertical"] {
+  &[aria-orientation='vertical'] {
     flex-direction: column;
 
-    &[data-variant="start"],
-    &[data-variant="center"] {
+    &[data-variant='start'],
+    &[data-variant='center'] {
       &:after {
         margin-bottom: 5%;
       }
     }
 
-    &[data-variant="end"],
-    &[data-variant="center"] {
+    &[data-variant='end'],
+    &[data-variant='center'] {
       &:before {
         margin-top: 5%;
       }

--- a/src/Divider/index.stories.tsx
+++ b/src/Divider/index.stories.tsx
@@ -30,12 +30,13 @@ const Template: React.FC<TemplateProps> = (args) => {
 export const DividerComponent = Template.bind({});
 DividerComponent.args = {
   title: 'Divider',
-  variant: 'fullWidth',
-  orientation: 'horizontal',
-  contentAlign: 'center',
-  component: 'div',
-  className: '',
   children: '',
+  variant: 'full',
+  orientation: 'horizontal',
+  align: 'center',
+  color: 'var(--sui-border)',
+  size: '1px',
+  round: false,
 };
 
 export const DividerWithVariant = Template.bind({});
@@ -56,7 +57,7 @@ export const DividerWithAlign = Template.bind({});
 DividerWithAlign.args = {
   ...DividerComponent.args,
   title: 'Divider with children',
-  contentAlign: 'start',
+  align: 'start',
   children: 'Hello World',
 };
 
@@ -72,19 +73,15 @@ const Component = {
   component: DividerComponent,
   argTypes: {
     variant: {
-      options: ['fullWidth', 'start', 'center', 'end'],
+      options: ['full', 'start', 'center', 'end'],
       control: 'radio',
     },
     orientation: {
       options: ['horizontal', 'vertical'],
       control: 'radio',
     },
-    contentAlign: {
+    align: {
       options: ['start', 'center', 'end'],
-      control: 'radio',
-    },
-    component: {
-      options: ['div', 'hr', 'li'],
       control: 'radio',
     },
   },

--- a/src/Divider/index.tsx
+++ b/src/Divider/index.tsx
@@ -1,56 +1,41 @@
-import { createElement, forwardRef } from 'react';
-import s from './Divider.module.scss';
+import React, { forwardRef } from 'react';
+import styles from './Divider.module.scss';
 import clsx from 'clsx';
 import type { DividerProps } from './types';
 
-const Divider = forwardRef<HTMLDivElement, DividerProps>((props, ref) => {
-  const {
-    children = null,
-    variant = 'fullWidth',
-    orientation = 'horizontal',
-    contentAlign = 'middle',
-    component = 'div',
-    className = '',
-    ...rest
-  } = props;
+const Divider = forwardRef<HTMLDivElement, DividerProps>(({
+  children,
+  className,
+  variant = "full",
+  orientation = "horizontal",
+  align = "center",
+  color = "var(--sui-border)",
+  size = "1px",
+  round = false,
+  style = {},
+  ...props
+}, ref) => {
+  const rootClassNames = clsx(className, styles.root);
 
-  const rootClassNames = clsx(s.root, className);
-
-  const componentParams = {
-    className: rootClassNames,
-    ref,
-    role: 'separator',
-    'aria-orientation': orientation,
-    'data-variant': variant,
-    'data-align': contentAlign,
-    ...rest,
-  };
-
-  // Void elements throw error if a child is passed: https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-  // Avoid passing child if a void element is used
-  const voidElements = [
-    'area',
-    'base',
-    'br',
-    'col',
-    'embed',
-    'hr',
-    'img',
-    'input',
-    'link',
-    'meta',
-    'param',
-    'source',
-    'track',
-    'wbr',
-  ];
-
-  // Return void divider
-  if (voidElements.includes(component))
-    return createElement(component, componentParams, null);
-
-  // Return normal divider
-  return createElement(component, componentParams, children);
+  return (
+    <div
+      className={rootClassNames}
+      role='separator'
+      aria-orientation={orientation}
+      data-variant={variant}
+      data-align={align}
+      data-round={`${round}`}
+      ref={ref}
+      style={{
+        "--sui-divider-color": color,
+        "--sui-divider-size": size,
+        ...style
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  )
 });
 
 Divider.displayName = 'Divider';

--- a/src/Divider/index.tsx
+++ b/src/Divider/index.tsx
@@ -3,40 +3,45 @@ import styles from './Divider.module.scss';
 import clsx from 'clsx';
 import type { DividerProps } from './types';
 
-const Divider = forwardRef<HTMLDivElement, DividerProps>(({
-  children,
-  className,
-  variant = "full",
-  orientation = "horizontal",
-  align = "center",
-  color = "var(--sui-border)",
-  size = "1px",
-  round = false,
-  style = {},
-  ...props
-}, ref) => {
-  const rootClassNames = clsx(className, styles.root);
+const Divider = forwardRef<HTMLDivElement, DividerProps>(
+  (
+    {
+      children,
+      className,
+      variant = 'full',
+      orientation = 'horizontal',
+      align = 'center',
+      color = 'var(--sui-border)',
+      size = '1px',
+      round = false,
+      style = {},
+      ...props
+    },
+    ref
+  ) => {
+    const rootClassNames = clsx(className, styles.root);
 
-  return (
-    <div
-      className={rootClassNames}
-      role='separator'
-      aria-orientation={orientation}
-      data-variant={variant}
-      data-align={align}
-      data-round={`${round}`}
-      ref={ref}
-      style={{
-        "--sui-divider-color": color,
-        "--sui-divider-size": size,
-        ...style
-      }}
-      {...props}
-    >
-      {children}
-    </div>
-  )
-});
+    return (
+      <div
+        className={rootClassNames}
+        role="separator"
+        aria-orientation={orientation}
+        data-variant={variant}
+        data-align={align}
+        data-round={`${round}`}
+        ref={ref}
+        style={{
+          '--sui-divider-color': color,
+          '--sui-divider-size': size,
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
 
 Divider.displayName = 'Divider';
 

--- a/src/Divider/types.ts
+++ b/src/Divider/types.ts
@@ -1,7 +1,7 @@
 export interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: "full" | "start" | "center" | "end";
-  orientation?: "horizontal" | "vertical";
-  align?: "start" | "center" | "end";
+  variant?: 'full' | 'start' | 'center' | 'end';
+  orientation?: 'horizontal' | 'vertical';
+  align?: 'start' | 'center' | 'end';
   color?: string;
   size?: `${string}px` | `${string}rem`;
   round?: boolean;

--- a/src/Divider/types.ts
+++ b/src/Divider/types.ts
@@ -1,14 +1,10 @@
-type Variant = 'fullWidth' | 'start' | 'center' | 'end';
-type Orientation = 'horizontal' | 'vertical';
-type ContentAlign = 'start' | 'center' | 'end';
-type Component = keyof JSX.IntrinsicElements;
-
-export interface DividerProps extends React.AllHTMLAttributes<HTMLDivElement> {
-  children?: React.ReactNode;
-  variant?: Variant;
-  orientation?: Orientation;
-  contentAlign?: ContentAlign;
-  component?: Component;
+export interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "full" | "start" | "center" | "end";
+  orientation?: "horizontal" | "vertical";
+  align?: "start" | "center" | "end";
+  color?: string;
+  size?: `${string}px` | `${string}rem`;
+  round?: boolean;
 }
 
 export interface TemplateProps extends DividerProps {


### PR DESCRIPTION
Completely rework Divider component and its documentation page.
- No longer accepts the following properties: `component` `contentAlign`.
- Has the following new properties: `align` `color` `size` `round`, which control the alignment of the children; color, size and the corner radius of the divider lines respectively.

These changes ensure that the Divider lines can be customized without the need for classNames.

The documentation page has more information about the properties and their accepted values.

These changes will break existing Divider components.
